### PR TITLE
Feature/update details

### DIFF
--- a/DataModel/datamodels/DataModels.cs
+++ b/DataModel/datamodels/DataModels.cs
@@ -3088,6 +3088,14 @@ namespace DataModel
         public string? UpdatedBy { get; set; }
 
         public string? UpdateSource { get; set; }
+
+        public IDictionary<string, UpdateHistory>? UpdateHistory { get; set; }
+    }
+
+    public class UpdateHistory
+    {
+        public DateTime? LastUpdate { get; set; }
+        public string? UpdateSource { get; set; }
     }
 
     public class LicenseInfo

--- a/DataModel/datamodels/DataModels.cs
+++ b/DataModel/datamodels/DataModels.cs
@@ -3076,7 +3076,14 @@ namespace DataModel
             }
         )]
         public string Type { get; set; }
+
+        [SwaggerSchema(Description = "Date when Data was lastly saved/updated")]
         public DateTime? LastUpdate { get; set; }
+
+        ////LAs
+        //[SwaggerSchema(Description = "Date when the Data had changes inside")]
+        //public DateTime? LastDataChange { get; set; }
+
         public string Source { get; set; }
         public bool Reduced { get; set; }
 
@@ -3086,16 +3093,16 @@ namespace DataModel
     public class UpdateInfo
     {
         public string? UpdatedBy { get; set; }
-
         public string? UpdateSource { get; set; }
 
-        public IDictionary<string, UpdateHistory>? UpdateHistory { get; set; }
+        //public ICollection<string, UpdateHistory>? UpdateHistory { get; set; }
     }
 
     public class UpdateHistory
     {
         public DateTime? LastUpdate { get; set; }
         public string? UpdateSource { get; set; }
+        public string? UpdatedBy { get; set; }
     }
 
     public class LicenseInfo

--- a/DataModel/datamodels/DataModels.cs
+++ b/DataModel/datamodels/DataModels.cs
@@ -3095,7 +3095,7 @@ namespace DataModel
         public string? UpdatedBy { get; set; }
         public string? UpdateSource { get; set; }
 
-        public ICollection<UpdateHistory> UpdateHistory { get; set; }
+        public ICollection<UpdateHistory>? UpdateHistory { get; set; }
     }
 
     public class UpdateHistory

--- a/DataModel/datamodels/DataModels.cs
+++ b/DataModel/datamodels/DataModels.cs
@@ -3095,7 +3095,7 @@ namespace DataModel
         public string? UpdatedBy { get; set; }
         public string? UpdateSource { get; set; }
 
-        //public ICollection<string, UpdateHistory>? UpdateHistory { get; set; }
+        public ICollection<UpdateHistory> UpdateHistory { get; set; }
     }
 
     public class UpdateHistory

--- a/DataModel/generic/JsonBData.cs
+++ b/DataModel/generic/JsonBData.cs
@@ -28,6 +28,7 @@ namespace DataModel
         public Int32 rawdataid { get; set; }
     }
 
+    #region RawDataStore
     public interface IRawDataStore
     {
         string type { get; set; }
@@ -92,4 +93,40 @@ namespace DataModel
                 return rawdatastore;
         }
     }
+
+    #endregion
+
+    #region RawChangesStore
+
+    public interface IRawChangesStore
+    {
+        string type { get; set; }
+        string datasource { get; set; }
+        string sourceid { get; set; }
+        string editedby { get; set; }
+        string editsource { get; set; }
+        DateTime date { get; set; }
+        JsonRaw changes { get; set; }
+        string license { get; set; }
+    }
+
+    public class RawChangesStore : IRawChangesStore
+    {
+        public string type { get; set; }
+        public string datasource { get; set; }
+        public string sourceid { get; set; }
+        public string editedby { get; set; }
+        public string editsource { get; set; }
+        public DateTime date { get; set; }
+        public JsonRaw changes { get; set; }
+        public string license { get; set; }
+    }
+
+    public class RawChangesStoreWithId : RawChangesStore
+    {
+        public int? id { get; set; }
+    }
+
+
+    #endregion
 }

--- a/Helper/Extensions/QueryFactoryExtension.cs
+++ b/Helper/Extensions/QueryFactoryExtension.cs
@@ -261,9 +261,7 @@ namespace Helper
                 UpdateSource = editinfo.Source,
             };
             //Setting the MetaData UpdateInfo.UpdateHistory
-            {
-                MetadataHelper.SetUpdateHistory(queryresult != null ? queryresult._Meta : null, data._Meta);
-            }
+            MetadataHelper.SetUpdateHistory(queryresult != null ? queryresult._Meta : null, data._Meta);
 
 
             //Setting Firstimport
@@ -733,10 +731,9 @@ namespace Helper
                 throw new ArgumentNullException(nameof(data), "no data");
 
             //Check if data exists
-            var query = QueryFactory.Query(table).Select("data").Where("id", data.Id);
-
-            var queryresult = await query.GetAsync<T>();
-
+            var queryresult = await QueryFactory.Query(table).Select("data").Where("id", data.Id)
+                .GetObjectSingleAsync<T>(); ;
+        
             string operation = "";
 
             int createresult = 0;
@@ -756,8 +753,10 @@ namespace Helper
                 UpdatedBy = editor,
                 UpdateSource = editsource,
             };
+            //Setting the MetaData UpdateInfo.UpdateHistory
+            MetadataHelper.SetUpdateHistory(queryresult != null ? queryresult._Meta : null, data._Meta);
 
-            if (queryresult == null || queryresult.Count() == 0)
+            if (queryresult == null)
             {
                 createresult = await QueryFactory
                     .Query(table)

--- a/Helper/Extensions/QueryFactoryExtension.cs
+++ b/Helper/Extensions/QueryFactoryExtension.cs
@@ -260,6 +260,12 @@ namespace Helper
                 UpdatedBy = editinfo.Editor,
                 UpdateSource = editinfo.Source,
             };
+            //Setting the MetaData UpdateInfo.UpdateHistory
+            {
+                MetadataHelper.SetUpdateHistory(queryresult != null ? queryresult._Meta : null, data._Meta);
+            }
+
+
             //Setting Firstimport
             if (data.FirstImport == null)
                 data.FirstImport = DateTime.Now;

--- a/Helper/Generic/DataOperationClasses.cs
+++ b/Helper/Generic/DataOperationClasses.cs
@@ -22,10 +22,11 @@ namespace Helper.Generic
 
     public class DataInfo
     {
-        public DataInfo(string table, CRUDOperation operation)
+        public DataInfo(string table, CRUDOperation operation, bool savechangestoDB = false)
         {
             Table = table;
             Operation = operation;
+            SaveChangesToDB = savechangestoDB;
 
             if (operation == CRUDOperation.Create)
             {
@@ -53,6 +54,8 @@ namespace Helper.Generic
         public CRUDOperation Operation { get; set; }
         public bool ErrorWhendataExists { get; set; }
         public bool ErrorWhendataIsNew { get; set; }
+
+        public bool SaveChangesToDB { get; set; }
     }
 
     public class CompareConfig

--- a/Helper/Generic/MetaInfoHelper.cs
+++ b/Helper/Generic/MetaInfoHelper.cs
@@ -461,5 +461,23 @@ namespace Helper
         {
             return GetMetadata(data, "noi", data.LastChange, false);
         }
+
+
+        public static void SetUpdateHistory(Metadata? oldmetadata, Metadata newmetadata)
+        {
+            if (oldmetadata == null && newmetadata.UpdateInfo != null && !String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
+                newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>() { { newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource } } };
+            else if (oldmetadata != null)
+            {
+                if (oldmetadata.UpdateInfo.UpdateHistory == null)
+                    newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>();
+                else
+                    newmetadata.UpdateInfo.UpdateHistory = oldmetadata.UpdateInfo.UpdateHistory;
+
+                newmetadata.UpdateInfo.UpdateHistory.TryAddOrUpdate(newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource });
+            }
+            else
+                newmetadata.UpdateInfo.UpdateHistory = null;
+        }
     }
 }

--- a/Helper/Generic/MetaInfoHelper.cs
+++ b/Helper/Generic/MetaInfoHelper.cs
@@ -465,19 +465,20 @@ namespace Helper
 
         public static void SetUpdateHistory(Metadata? oldmetadata, Metadata newmetadata)
         {
-            if (oldmetadata == null && newmetadata.UpdateInfo != null && !String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
-                newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>() { { newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource } } };
-            else if (oldmetadata != null)
-            {
-                if (oldmetadata.UpdateInfo.UpdateHistory == null)
-                    newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>();
-                else
-                    newmetadata.UpdateInfo.UpdateHistory = oldmetadata.UpdateInfo.UpdateHistory;
+            //if (oldmetadata == null && newmetadata.UpdateInfo != null && !String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
+            //    newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>() { { newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource } } };
+            //else if (oldmetadata != null)
+            //{
+            //    if (oldmetadata.UpdateInfo.UpdateHistory == null)
+            //        newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>();
+            //    else
+            //        newmetadata.UpdateInfo.UpdateHistory = oldmetadata.UpdateInfo.UpdateHistory;
 
-                newmetadata.UpdateInfo.UpdateHistory.TryAddOrUpdate(newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource });
-            }
-            else
-                newmetadata.UpdateInfo.UpdateHistory = null;
+            //    if(!String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
+            //        newmetadata.UpdateInfo.UpdateHistory.TryAddOrUpdate(newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource });
+            //}
+            //else
+            //    newmetadata.UpdateInfo.UpdateHistory = null;
         }
     }
 }

--- a/Helper/Generic/MetaInfoHelper.cs
+++ b/Helper/Generic/MetaInfoHelper.cs
@@ -36,7 +36,7 @@ namespace Helper
         public static Metadata GetMetadata<T>(
             T data,
             string source,
-            DateTime? lastupdated = null,
+            //DateTime? lastupdated = null,
             bool reduced = false
         )
             where T : IIdentifiable, IMetaData
@@ -51,7 +51,8 @@ namespace Helper
             {
                 Id = data.Id,
                 Type = type,
-                LastUpdate = lastupdated,
+                //LastUpdate = lastupdated,
+                LastUpdate = DateTime.Now,
                 Source = source,
                 Reduced = reduced,
             };
@@ -126,7 +127,7 @@ namespace Helper
                 datasource = datasource.ToLower();
             }
 
-            return GetMetadata(data, datasource, data.LastChange, reduced);
+            return GetMetadata(data, datasource, reduced);
         }
 
         public static Metadata GetMetadataforAccommodationRoom(AccommodationRoomLinked data)
@@ -146,7 +147,7 @@ namespace Helper
                 datasource = datasource.ToLower();
             }
 
-            return GetMetadata(data, datasource, data.LastChange, false);
+            return GetMetadata(data, datasource, false);
         }
 
         public static Metadata GetMetadataforActivity(LTSActivityLinked data)
@@ -159,7 +160,7 @@ namespace Helper
             if (data.Source != null)
                 sourcemeta = data.Source.ToLower();
 
-            return GetMetadata(data, sourcemeta, data.LastChange, reduced);
+            return GetMetadata(data, sourcemeta, reduced);
         }
 
         public static Metadata GetMetadataforPoi(LTSPoiLinked data)
@@ -168,7 +169,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return GetMetadata(data, "lts", data.LastChange, reduced);
+            return GetMetadata(data, "lts", reduced);
         }
 
         public static Metadata GetMetadataforGastronomy(GastronomyLinked data)
@@ -177,7 +178,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return GetMetadata(data, "lts", data.LastChange, reduced);
+            return GetMetadata(data, "lts", reduced);
         }
 
         public static Metadata GetMetadataforEvent(EventLinked data)
@@ -187,7 +188,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return GetMetadata(data, sourcemeta, data.LastChange, reduced);
+            return GetMetadata(data, sourcemeta, reduced);
         }
 
         public static Metadata GetMetadataforEvent(EventV2 data)
@@ -197,7 +198,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return GetMetadata(data, sourcemeta, data.LastChange, reduced);
+            return GetMetadata(data, sourcemeta, reduced);
         }
 
         public static Metadata GetMetadataforOdhActivityPoi(ODHActivityPoiLinked data)
@@ -211,7 +212,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return GetMetadata(data, sourcemeta ?? "", data.LastChange, reduced);
+            return GetMetadata(data, sourcemeta ?? "", reduced);
         }
 
         public static Metadata GetMetadataforOdhTag(ODHTagLinked data)
@@ -221,33 +222,33 @@ namespace Helper
             if (data.Source != null && data.Source.Contains("LTSCategory"))
                 sourcemeta = "lts";
 
-            return GetMetadata(data, sourcemeta, data.LastChange);
+            return GetMetadata(data, sourcemeta);
         }
 
         public static Metadata GetMetadataforTag(TagLinked data)
         {
             string sourcemeta = data.Source.ToLower();
 
-            return GetMetadata(data, sourcemeta, data.LastChange);
+            return GetMetadata(data, sourcemeta);
         }
 
         public static Metadata GetMetadataforPublisher(PublisherLinked data)
         {
             string sourcemeta = "noi";
 
-            return GetMetadata(data, sourcemeta, data.LastChange);
+            return GetMetadata(data, sourcemeta);
         }
 
         public static Metadata GetMetadataforSource(SourceLinked data)
         {
             string sourcemeta = "noi";
 
-            return GetMetadata(data, sourcemeta, data.LastChange);
+            return GetMetadata(data, sourcemeta);
         }
 
         public static Metadata GetMetadataforPackage(PackageLinked data)
         {
-            return GetMetadata(data, "hgv", data.LastUpdate, false);
+            return GetMetadata(data, "hgv", false);
         }
 
         public static Metadata GetMetadataforMeasuringpoint(MeasuringpointLinked data)
@@ -256,7 +257,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return GetMetadata(data, "lts", data.LastChange, reduced);
+            return GetMetadata(data, "lts", reduced);
         }
 
         public static Metadata GetMetadataforWebcam(WebcamInfoLinked data)
@@ -269,7 +270,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return GetMetadata(data, sourcemeta, data.LastChange, reduced);
+            return GetMetadata(data, sourcemeta, reduced);
         }
 
         public static Metadata GetMetadataforArticle(ArticlesLinked data)
@@ -282,7 +283,7 @@ namespace Helper
             if (sourcemeta == "content")
                 sourcemeta = "idm";
 
-            return GetMetadata(data, sourcemeta, data.LastChange, false);
+            return GetMetadata(data, sourcemeta, false);
         }
 
         public static Metadata GetMetadataforDDVenue(DDVenue data)
@@ -291,7 +292,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return data._Meta = GetMetadata(data, "lts", data.meta?.lastUpdate, reduced);
+            return data._Meta = GetMetadata(data, "lts", reduced);
         }
 
         public static Metadata GetMetadataforVenue(VenueLinked data)
@@ -300,7 +301,7 @@ namespace Helper
             if (data._Meta != null)
                 reduced = (bool)data._Meta.Reduced;
 
-            return data._Meta = GetMetadata(data, "lts", data.LastChange, reduced);
+            return data._Meta = GetMetadata(data, "lts", reduced);
         }
 
         public static Metadata GetMetadataforVenue(VenueV2 data)
@@ -313,7 +314,7 @@ namespace Helper
             if (data.Source != null)
                 sourcemeta = data.Source.ToLower();
 
-            return data._Meta = GetMetadata(data, sourcemeta, data.LastChange, reduced);
+            return data._Meta = GetMetadata(data, sourcemeta, reduced);
         }
 
         public static Metadata GetMetadataforEventShort(EventShortLinked data)
@@ -327,62 +328,62 @@ namespace Helper
                 "nobis" => "nobis",
                 _ => sourcemeta,
             };
-            return GetMetadata(data, sourcestr, data.LastChange, false);
+            return GetMetadata(data, sourcestr, false);
         }
 
         public static Metadata GetMetadataforExperienceArea(ExperienceAreaLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm", false);
         }
 
         public static Metadata GetMetadataforMetaRegion(MetaRegionLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm", false);
         }
 
         public static Metadata GetMetadataforRegion(RegionLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm", false);
         }
 
         public static Metadata GetMetadataforTourismverein(TourismvereinLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm", false);
         }
 
         public static Metadata GetMetadataforMunicipality(MunicipalityLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm", false);
         }
 
         public static Metadata GetMetadataforDistrict(DistrictLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm", false);
         }
 
         public static Metadata GetMetadataforSkiArea(SkiAreaLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm", false);
         }
 
         public static Metadata GetMetadataforSkiRegion(SkiRegionLinked data)
         {
-            return GetMetadata(data, "idm", data.LastChange, false);
+            return GetMetadata(data, "idm",  false);
         }
 
         public static Metadata GetMetadataforArea(AreaLinked data)
         {
-            return GetMetadata(data, "lts", data.LastChange, false);
+            return GetMetadata(data, "lts", false);
         }
 
         public static Metadata GetMetadataforWineAward(WineLinked data)
         {
-            return GetMetadata(data, "suedtirolwein", data.LastChange, false);
+            return GetMetadata(data, "suedtirolwein", false);
         }
 
         public static Metadata GetMetaDataForWeatherHistory(WeatherHistoryLinked data)
         {
-            return GetMetadata(data, "siag", data.LastChange, false);
+            return GetMetadata(data, "siag", false);
         }
 
         //Hack because WeatherLinked is not IIdentifiable so return directly
@@ -459,7 +460,7 @@ namespace Helper
 
         public static Metadata GetMetaDataForMetaData(TourismMetaData data)
         {
-            return GetMetadata(data, "noi", data.LastChange, false);
+            return GetMetadata(data, "noi", false);
         }
 
 

--- a/Helper/Generic/MetaInfoHelper.cs
+++ b/Helper/Generic/MetaInfoHelper.cs
@@ -489,7 +489,7 @@ namespace Helper
                     }
                     else
                     {
-                        newmetadata.UpdateInfo.UpdateHistory.Add(new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource, UpdatedBy = newmetadata.UpdateInfo.UpdatedBy })
+                        newmetadata.UpdateInfo.UpdateHistory.Add(new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource, UpdatedBy = newmetadata.UpdateInfo.UpdatedBy });
                     }
                 }
                     //newmetadata.UpdateInfo.UpdateHistory.  TryAddOrUpdate(, );

--- a/Helper/Generic/MetaInfoHelper.cs
+++ b/Helper/Generic/MetaInfoHelper.cs
@@ -465,20 +465,37 @@ namespace Helper
 
         public static void SetUpdateHistory(Metadata? oldmetadata, Metadata newmetadata)
         {
-            //if (oldmetadata == null && newmetadata.UpdateInfo != null && !String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
-            //    newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>() { { newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource } } };
-            //else if (oldmetadata != null)
-            //{
-            //    if (oldmetadata.UpdateInfo.UpdateHistory == null)
-            //        newmetadata.UpdateInfo.UpdateHistory = new Dictionary<string, UpdateHistory>();
-            //    else
-            //        newmetadata.UpdateInfo.UpdateHistory = oldmetadata.UpdateInfo.UpdateHistory;
+            if (oldmetadata == null && newmetadata.UpdateInfo != null && !String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
+            {
+                //New dataset
+                newmetadata.UpdateInfo.UpdateHistory =
+                [
+                    new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource, UpdatedBy = newmetadata.UpdateInfo.UpdatedBy },
+                ];
+            }
+            else if (oldmetadata != null)
+            {
+                if (oldmetadata.UpdateInfo.UpdateHistory == null)
+                    newmetadata.UpdateInfo.UpdateHistory = new List<UpdateHistory>();
+                else
+                    newmetadata.UpdateInfo.UpdateHistory = oldmetadata.UpdateInfo.UpdateHistory;
 
-            //    if(!String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
-            //        newmetadata.UpdateInfo.UpdateHistory.TryAddOrUpdate(newmetadata.UpdateInfo.UpdatedBy, new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource });
-            //}
-            //else
-            //    newmetadata.UpdateInfo.UpdateHistory = null;
+                if (!String.IsNullOrEmpty(newmetadata.UpdateInfo.UpdatedBy))
+                {
+                    if(newmetadata.UpdateInfo.UpdateHistory.Where(x => x.UpdatedBy == newmetadata.UpdateInfo.UpdatedBy).Count() > 0)
+                    {
+                        var updatehistorytoupdate = newmetadata.UpdateInfo.UpdateHistory.Where(x => x.UpdatedBy == newmetadata.UpdateInfo.UpdatedBy && x.UpdateSource == newmetadata.UpdateInfo.UpdateSource).FirstOrDefault();
+                        updatehistorytoupdate.LastUpdate = newmetadata.LastUpdate;
+                    }
+                    else
+                    {
+                        newmetadata.UpdateInfo.UpdateHistory.Add(new UpdateHistory() { LastUpdate = newmetadata.LastUpdate, UpdateSource = newmetadata.UpdateInfo.UpdateSource, UpdatedBy = newmetadata.UpdateInfo.UpdatedBy })
+                    }
+                }
+                    //newmetadata.UpdateInfo.UpdateHistory.  TryAddOrUpdate(, );
+            }
+            else
+                newmetadata.UpdateInfo.UpdateHistory = null;
         }
     }
 }

--- a/NINJA/GetNinjaInfo.cs
+++ b/NINJA/GetNinjaInfo.cs
@@ -91,10 +91,11 @@ namespace NINJA
 
         public static async Task<
             NinjaObjectWithParent<NinjaEchargingPlug, NinjaEchargingStation>
-        > GetNinjaEchargingPlugs(string serviceurl)
+        > GetNinjaEchargingPlugs(string serviceurl, bool onlyactive = true)
         {
-            string placeselect =
-                $"EChargingPlug?limit=0&where=sactive.eq.true,scoordinate.bbc.({NinjaHelper.GetBoundingBoxForSouthTyrol()})";
+            string placeselect = onlyactive ?
+                $"EChargingPlug?limit=0&where=sactive.eq.true,scoordinate.bbc.({NinjaHelper.GetBoundingBoxForSouthTyrol()})"
+                : $"EChargingPlug?limit=0&where=scoordinate.bbc.({NinjaHelper.GetBoundingBoxForSouthTyrol()})"; 
 
             var requesturl = serviceurl + placeselect;
 

--- a/OdhApiCore/Controllers/api/ODHActivityPoiController.cs
+++ b/OdhApiCore/Controllers/api/ODHActivityPoiController.cs
@@ -731,7 +731,7 @@ namespace OdhApiCore.Controllers.api
 
                 return await UpsertData<ODHActivityPoiLinked>(
                     odhactivitypoi,
-                    new DataInfo("smgpois", CRUDOperation.Update),
+                    new DataInfo("smgpois", CRUDOperation.Update, true),
                     new CompareConfig(true, true),
                     new CRUDConstraints(additionalfilter, UserRolesToFilter)
                 );

--- a/OdhApiCore/Controllers/base/OdhController.cs
+++ b/OdhApiCore/Controllers/base/OdhController.cs
@@ -274,10 +274,10 @@ namespace OdhApiCore.Controllers
             where T : IIdentifiable, IImportDateassigneable, IMetaData, new()
         {
             //TODO Username and provenance of the insert/edit
-            //Get the Username
+            //Get the Name Identifier TO CHECK what about service accounts?
             string editor =
-                this.User != null && this.User.Identity != null && this.User.Identity.Name != null
-                    ? this.User.Identity.Name
+                this.User != null && this.User.Claims != null ? 
+                this.User.Claims.Where(x => x.Type == ClaimTypes.NameIdentifier).FirstOrDefault().Value
                     : "anonymous";
 
             if (

--- a/OdhApiImporter/Helpers/A22/A22PoiImportHelper.cs
+++ b/OdhApiImporter/Helpers/A22/A22PoiImportHelper.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using A22;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using ServiceReferenceLCS;
 using SqlKata.Execution;
 
@@ -243,11 +244,11 @@ namespace OdhApiImporter.Helpers
 
             var pgcrudresult = await QueryFactory.UpsertData<ODHActivityPoiLinked>(
                 odhactivitypoi,
-                table,
-                rawdataid,
-                "a22." + a22poiinfo.entitytype + ".import",
-                importerURL
-            );
+                new DataInfo(table, Helper.Generic.CRUDOperation.CreateAndUpdate),
+                new EditInfo("a22." + a22poiinfo.entitytype + ".import", importerURL),
+                new CRUDConstraints(),
+                new CompareConfig(true, false),
+                rawdataid);
 
             return pgcrudresult;
         }

--- a/OdhApiImporter/Helpers/A22/A22WebcamImportHelper.cs
+++ b/OdhApiImporter/Helpers/A22/A22WebcamImportHelper.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using A22;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using ServiceReferenceLCS;
 using SqlKata.Execution;
 
@@ -217,10 +218,11 @@ namespace OdhApiImporter.Helpers
 
             var pgcrudresult = await QueryFactory.UpsertData<WebcamInfoLinked>(
                 webcam,
-                table,
-                rawdataid,
-                "a22.webcam.import",
-                importerURL
+                new DataInfo(table, Helper.Generic.CRUDOperation.CreateAndUpdate),
+                new EditInfo("a22.webcam.import", importerURL),
+                new CRUDConstraints(),
+                new CompareConfig(true, false),
+                rawdataid
             );
 
             return pgcrudresult;

--- a/OdhApiImporter/Helpers/DSS/DSSImportHelper.cs
+++ b/OdhApiImporter/Helpers/DSS/DSSImportHelper.cs
@@ -626,10 +626,11 @@ namespace OdhApiImporter.Helpers.DSS
 
                 var pgcrudresult = await QueryFactory.UpsertData<ODHActivityPoiLinked>(
                     odhactivitypoi,
-                    table,
-                    rawdataid,
-                    "dss." + entitytype + ".import",
-                    importerURL
+                    new DataInfo(table, Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("dss." + entitytype + ".import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
 
                 //Publishedon Helper?

--- a/OdhApiImporter/Helpers/DSS/DSSSkiAreaImportHelper.cs
+++ b/OdhApiImporter/Helpers/DSS/DSSSkiAreaImportHelper.cs
@@ -212,7 +212,7 @@ namespace OdhApiImporter.Helpers.DSS
                 new DataInfo(table, CRUDOperation.Update),
                 new EditInfo("dss.skiarea.import", importerURL),
                 new CRUDConstraints(),
-                new CompareConfig(false, false)
+                new CompareConfig(true, false)
             );
         }
 

--- a/OdhApiImporter/Helpers/DSS/DSSWebcamImportHelper.cs
+++ b/OdhApiImporter/Helpers/DSS/DSSWebcamImportHelper.cs
@@ -14,6 +14,7 @@ using DataModel;
 using DSS;
 using DSS.Parser;
 using Helper;
+using Helper.Generic;
 using Newtonsoft.Json;
 using ServiceReferenceLCS;
 using SqlKata.Execution;
@@ -327,10 +328,11 @@ namespace OdhApiImporter.Helpers.DSS
 
             var pgcrudresult = await QueryFactory.UpsertData<WebcamInfoLinked>(
                 webcam,
-                table,
-                rawdataid,
-                "dss.webcam.import",
-                importerURL
+                new DataInfo(table, Helper.Generic.CRUDOperation.CreateAndUpdate),
+                new EditInfo("dss.webcam.import", importerURL),
+                new CRUDConstraints(),
+                new CompareConfig(true, false),
+                rawdataid
             );
 
             return pgcrudresult;

--- a/OdhApiImporter/Helpers/EBMS/EBMSImportHelper.cs
+++ b/OdhApiImporter/Helpers/EBMS/EBMSImportHelper.cs
@@ -12,6 +12,7 @@ using EBMS;
 using Helper;
 using Helper.Extensions;
 using Helper.Tagging;
+using Helper.Generic;
 using Newtonsoft.Json;
 using SqlKata.Execution;
 
@@ -301,10 +302,11 @@ namespace OdhApiImporter.Helpers
 
                 return await QueryFactory.UpsertData<EventShortLinked>(
                     eventshort,
-                    "eventeuracnoi",
-                    rawdataid,
-                    "ebms.eventshort.import",
-                    importerURL
+                    new DataInfo("eventeuracnoi", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("ebms.eventshort.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/FERATEL/FeratelWebcamImportHelper.cs
+++ b/OdhApiImporter/Helpers/FERATEL/FeratelWebcamImportHelper.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using DataModel;
 using FERATEL;
 using Helper;
+using Helper.Generic;
 using Newtonsoft.Json;
 using SqlKata.Execution;
 
@@ -214,10 +215,11 @@ namespace OdhApiImporter.Helpers
 
             var pgcrudresult = await QueryFactory.UpsertData<WebcamInfoLinked>(
                 webcam,
-                table,
-                rawdataid,
-                "feratel.webcam.import",
-                importerURL
+                new DataInfo(table, Helper.Generic.CRUDOperation.CreateAndUpdate),
+                new EditInfo("feratel.webcam.import", importerURL),
+                new CRUDConstraints(),
+                new CompareConfig(true, false),
+                rawdataid
             );
 
             return pgcrudresult;

--- a/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationCategoriesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationCategoriesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -262,10 +263,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.accommodations.categories.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.accommodations.categories.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationImportHelper.cs
@@ -12,6 +12,7 @@ using System.Xml.Linq;
 using Amazon.Util.Internal;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Tagging;
 using LTSAPI;
 using LTSAPI.Parser;
@@ -317,10 +318,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<AccommodationV2>(
                     objecttosave,
-                    "accommodations",
-                    rawdataid,
-                    "lts.accommodations.import",
-                    importerURL
+                    new DataInfo("accommodations", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.accommodations.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationMealplansImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationMealplansImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -263,17 +264,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.accommodations.mealplans.import",
-                    importerURL
-                );
-                return await QueryFactory.UpsertData<TagLinked>(
-                    objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.accommodations.mealplans.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.accommodations.mealplans.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationRateplansImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationRateplansImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -266,10 +267,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "rateplans",
-                    rawdataid,
-                    "lts.accommodations.rateplans.import",
-                    importerURL
+                    new DataInfo("rateplans", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.accommodations.rateplans.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationTypesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAccommodationTypesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -260,10 +261,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.accommodations.types.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.accommodations.types.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAmenitiesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/accommodation/LTSApiAmenitiesImportHelper.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -287,10 +288,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.accommodations.amenities.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.accommodations.amenities.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/event/LTSApiEventCategoriesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/event/LTSApiEventCategoriesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -254,10 +255,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.events.categories.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.events.categories.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/event/LTSApiEventClassificationsImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/event/LTSApiEventClassificationsImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -253,10 +254,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.events.classifications.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.events.classifications.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/event/LTSApiEventTagsImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/event/LTSApiEventTagsImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -251,10 +252,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.events.tags.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.events.tags.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiCeremonyCodesFacilitiesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiCeremonyCodesFacilitiesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -264,10 +265,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.gastronomies.ceremonycodes.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.gastronomies.ceremonycodes.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiGastronomyCategoriesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiGastronomyCategoriesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -265,10 +266,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.gastronomies.categories.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.gastronomies.categories.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiGastronomyDishCodesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiGastronomyDishCodesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -258,10 +259,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.gastronomies.dishcodes.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.gastronomies.dishcodes.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiGastronomyFacilitiesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/gastronomy/LTSApiGastronomyFacilitiesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -271,10 +272,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.gastronomies.facilities.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.gastronomies.facilities.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/guestcard/LTSApiGuestCardImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/guestcard/LTSApiGuestCardImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -264,10 +265,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.suedtirolguestpass.cardtypes.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.suedtirolguestpass.cardtypes.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/tag/LTSApiTagImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/tag/LTSApiTagImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -265,10 +266,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.tags.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.tags.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/LTSAPI/venue/LTSApiVenueCategoriesImportHelper.cs
+++ b/OdhApiImporter/Helpers/LTSAPI/venue/LTSApiVenueCategoriesImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using LTSAPI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -263,10 +264,11 @@ namespace OdhApiImporter.Helpers.LTSAPI
 
                 return await QueryFactory.UpsertData<TagLinked>(
                     objecttosave,
-                    "tags",
-                    rawdataid,
-                    "lts.venues.categories.import",
-                    importerURL
+                    new DataInfo("tags", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("lts.venues.categories.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/NINJA/MobilityEchargingImportHelper.cs
+++ b/OdhApiImporter/Helpers/NINJA/MobilityEchargingImportHelper.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Location;
 using Helper.Tagging;
 using Microsoft.FSharp.Control;
@@ -258,10 +259,11 @@ namespace OdhApiImporter.Helpers
 
                 return await QueryFactory.UpsertData<ODHActivityPoiLinked>(
                     objecttosave,
-                    "smgpois",
-                    rawdataid,
-                    "mobility.echarging.import",
-                    importerURL
+                    new DataInfo("smgpois", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("mobility.echarging.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/NINJA/MobilityEchargingImportHelper.cs
+++ b/OdhApiImporter/Helpers/NINJA/MobilityEchargingImportHelper.cs
@@ -314,6 +314,8 @@ namespace OdhApiImporter.Helpers
                     {
                         data.Active = false;
                         data.SmgActive = false;
+                        data.LastChange = DateTime.Now;
+                        data._Meta.LastUpdate = DateTime.Now;
 
                         updateresult = await QueryFactory
                             .Query("smgpois")
@@ -448,6 +450,8 @@ namespace OdhApiImporter.Helpers
                     )
                 );
             }
+            //Hack for alperia stations
+            listtoreturn.Add(Tuple.Create("alperia", "alperia"));
 
             return listtoreturn;
         }

--- a/OdhApiImporter/Helpers/NINJA/MobilityEventsImportHelper.cs
+++ b/OdhApiImporter/Helpers/NINJA/MobilityEventsImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Location;
 using Newtonsoft.Json;
 using NINJA;
@@ -241,10 +242,11 @@ namespace OdhApiImporter.Helpers
 
                 return await QueryFactory.UpsertData<EventLinked>(
                     eventtosave,
-                    "events",
-                    rawdataid,
-                    "mobility.event.import",
-                    importerURL
+                    new DataInfo("events", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("mobility.event.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/NINJA/MobilityEventsV2ImportHelper.cs
+++ b/OdhApiImporter/Helpers/NINJA/MobilityEventsV2ImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Location;
 using Newtonsoft.Json;
 using NINJA;
@@ -217,10 +218,11 @@ namespace OdhApiImporter.Helpers
 
                 return await QueryFactory.UpsertData<EventV2>(
                     eventtosave,
-                    "eventsv2",
-                    rawdataid,
-                    "mobility.eventv2.import",
-                    importerURL
+                    new DataInfo("eventsv2", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("mobility.eventv2.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/NINJA/MobilityVenuesV2ImportHelper.cs
+++ b/OdhApiImporter/Helpers/NINJA/MobilityVenuesV2ImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Location;
 using MSS;
 using Newtonsoft.Json;
@@ -227,10 +228,11 @@ namespace OdhApiImporter.Helpers
 
                 return await QueryFactory.UpsertData<VenueV2>(
                     venuetosave,
-                    "venuesv2",
-                    rawdataid,
-                    "mobility.venuev2.import",
-                    importerURL
+                    new DataInfo("venuesv2", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("mobility.venuev2.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
                 );
             }
             catch (Exception ex)

--- a/OdhApiImporter/Helpers/PANOCLOUD/PanocloudImportHelper.cs
+++ b/OdhApiImporter/Helpers/PANOCLOUD/PanocloudImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Newtonsoft.Json;
 using PANOCLOUD;
 using SqlKata.Execution;
@@ -195,10 +196,11 @@ namespace OdhApiImporter.Helpers
 
             var pgcrudresult = await QueryFactory.UpsertData<WebcamInfoLinked>(
                 webcam,
-                table,
-                rawdataid,
-                "panocloud.webcam.import",
-                importerURL
+                new DataInfo(table, Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("panocloud.webcam.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid                
             );
 
             return pgcrudresult;

--- a/OdhApiImporter/Helpers/PANOMAX/PanomaxImportHelper.cs
+++ b/OdhApiImporter/Helpers/PANOMAX/PanomaxImportHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Newtonsoft.Json;
 using PANOMAX;
 using SqlKata.Execution;
@@ -211,10 +212,11 @@ namespace OdhApiImporter.Helpers
 
             var pgcrudresult = await QueryFactory.UpsertData<WebcamInfoLinked>(
                 webcam,
-                table,
-                rawdataid,
-                "panomax.webcam.import",
-                importerURL
+                new DataInfo(table, Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("panomax.webcam.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
             );
 
             return pgcrudresult;

--- a/OdhApiImporter/Helpers/RAVEN/RAVENImportHelper.cs
+++ b/OdhApiImporter/Helpers/RAVEN/RAVENImportHelper.cs
@@ -1432,7 +1432,7 @@ namespace OdhApiImporter.Helpers
             var result = await QueryFactory.UpsertData<T>(
                 datatosave,
                 new DataInfo(table, CRUDOperation.Update) { ErrorWhendataIsNew = false },
-                new EditInfo("lts.push.import", "odh.importer"),
+                new EditInfo("lts.push.import", importerURL),
                 new CRUDConstraints(),
                 new CompareConfig(compareresult, compareimagechange)
             );

--- a/OdhApiImporter/Helpers/SIAG/SiagMuseumImportHelper.cs
+++ b/OdhApiImporter/Helpers/SIAG/SiagMuseumImportHelper.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Location;
 using Newtonsoft.Json;
 using ServiceReferenceLCS;
@@ -696,10 +697,11 @@ namespace OdhApiImporter.Helpers
 
             return await QueryFactory.UpsertData<ODHActivityPoiLinked>(
                 odhactivitypoi,
-                "smgpois",
-                rawdataid,
-                "siag.museum.import",
-                importerURL
+                new DataInfo("smgpois", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("siag.museum.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
             );
         }
 

--- a/OdhApiImporter/Helpers/SIAG/SiagWeatherImportHelper.cs
+++ b/OdhApiImporter/Helpers/SIAG/SiagWeatherImportHelper.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.S3;
 using Newtonsoft.Json;
 using SIAG;
@@ -317,11 +318,11 @@ namespace OdhApiImporter.Helpers
 
                 var insertresult = await QueryFactory.UpsertData<WeatherHistoryLinked>(
                     myweatherhistory,
-                    "weatherdatahistory",
-                    insertresultraw,
-                    "siag.weather.import",
-                    importerURL,
-                    true
+                    new DataInfo("weatherdatahistory", Helper.Generic.CRUDOperation.Create),
+                    new EditInfo("siag.weather.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    insertresultraw
                 );
 
                 //var insertresult = await QueryFactory.Query("weatherdatahistory")

--- a/OdhApiImporter/Helpers/STA/STAImportHelper.cs
+++ b/OdhApiImporter/Helpers/STA/STAImportHelper.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Location;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
@@ -157,10 +158,11 @@ namespace OdhApiImporter.Helpers
                                 //Check if data exists
                                 var result = await QueryFactory.UpsertData(
                                     odhactivitypoi,
-                                    "smgpois",
-                                    rawdataid,
-                                    "sta.vendingpoint.import",
-                                    importerURL
+                                    new DataInfo("smgpois", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                                    new EditInfo("sta.vendingpoint.import", importerURL),
+                                    new CRUDConstraints(),
+                                    new CompareConfig(true, false),
+                                    rawdataid
                                 );
 
                                 idlistspreadsheet.Add(odhactivitypoi.Id);

--- a/OdhApiImporter/Helpers/SUEDTIROLWEIN/SuedtirolWeinAwardImportHelper.cs
+++ b/OdhApiImporter/Helpers/SUEDTIROLWEIN/SuedtirolWeinAwardImportHelper.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using SqlKata.Execution;
 using SuedtirolWein;
 using SuedtirolWein.Parser;
@@ -295,10 +296,11 @@ namespace OdhApiImporter.Helpers.SuedtirolWein
             //TODO Add column rawdataid
             return await QueryFactory.UpsertData<WineLinked>(
                 wineaward,
-                "wines",
-                rawdataid,
-                "suedtirolwein.weinaward.import",
-                importerURL
+                new DataInfo("wines", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("suedtirolwein.weinaward.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
             );
         }
 

--- a/OdhApiImporter/Helpers/SUEDTIROLWEIN/SuedtirolWeinCompanyImportHelper.cs
+++ b/OdhApiImporter/Helpers/SUEDTIROLWEIN/SuedtirolWeinCompanyImportHelper.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using Amazon.Runtime.Internal.Transform;
 using DataModel;
 using Helper;
+using Helper.Generic;
 using Helper.Location;
 using SqlKata.Execution;
 using SuedtirolWein;
@@ -611,10 +612,11 @@ namespace OdhApiImporter.Helpers.SuedtirolWein
 
             return await QueryFactory.UpsertData<ODHActivityPoiLinked>(
                 odhactivitypoi,
-                "smgpois",
-                rawdataid,
-                "suedtirolwein.company.import",
-                importerURL
+                new DataInfo("smgpois", Helper.Generic.CRUDOperation.CreateAndUpdate),
+                    new EditInfo("suedtirolwein.company.import", importerURL),
+                    new CRUDConstraints(),
+                    new CompareConfig(true, false),
+                    rawdataid
             );
         }
 


### PR DESCRIPTION
This PR optimizes/adds

- merging upsert method into one
- possibility of saving changes on a dataset into the `rawchanges` Table
- Different usage of _Meta.LastUpdate (When was the dataset last updated)  and LastChange (When did the dataset had a real last change) on Root
- Adding the Information to _Meta.UpdateHistory if the dataset was modified by more sources
- Saving the Keycloak id instead of the UserId on _Meta.UpdateHistory